### PR TITLE
Change dice image URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An alternative property-based testing system for F#, in the spirit of John Hughe
 
 The key improvement is that shrinking comes for free — instead of generating a random value and using a shrinking function after the fact, we generate the random value and all the possible shrinks in a rose tree, all at once.
 
-![](https://github.com/moodmosaic/dotnet-jack/raw/master/img/dice.jpg)
+![](https://github.com/hedgehogqa/dotnet-hedgehog/raw/master/img/dice.jpg)
 
 ## Table of Contents
 


### PR DESCRIPTION
So that it shows up correctly on the README. Right now it points to the old repo, which no longer exists.