### PR TITLE
Add build target for creating a NuGet package locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ Thumbs.db
 #dotCover
 *.dotCover
 
+# Hedgehog NuGet Package output directory
+.nuget
+
 # FAKE - F# Make
 .fake/
 

--- a/Hedgehog/AssemblyInfo.fs
+++ b/Hedgehog/AssemblyInfo.fs
@@ -10,9 +10,9 @@ open System.Runtime.CompilerServices
 [<assembly: AssemblyCopyright("${AuthorCopyright}")>]
 [<assembly: AssemblyTrademark("")>]
 
-// The assembly version has the format {Major}.{Minor}.{Build}.{Revision}
+// The assembly version has the format {Major}.{Minor}.{Build}
 
-[<assembly: AssemblyVersion("1.0.0.0")>]
+[<assembly: AssemblyVersion("0.1.0")>]
 
 //[<assembly: AssemblyDelaySign(false)>]
 //[<assembly: AssemblyKeyFile("")>]

--- a/Hedgehog/paket.template
+++ b/Hedgehog/paket.template
@@ -1,0 +1,20 @@
+type
+    project
+id
+    Hedgehog
+description
+    Hedgehog will eat all your bugs.
+authors
+    Jacob Stanley, Nikos Baxevanis
+copyright
+    Copyright 2017
+summary
+    An alternative property-based testing system for F#, in the spirit of QuickCheck. The key improvement is that shrinking comes for free.
+licenseurl
+    https://raw.githubusercontent.com/hedgehogqa/dotnet-hedgehog/master/LICENSE
+projecturl
+    https://github.com/hedgehogqa/dotnet-hedgehog
+iconUrl
+    https://github.com/hedgehogqa/dotnet-hedgehog/raw/master/img/SQUARE_hedgehog_300x300.png
+tags
+    fsharp, f#, testing

--- a/build.fsx
+++ b/build.fsx
@@ -12,7 +12,11 @@ Target "Test" (fun _ ->
     !! "*/bin/Release/*Hedgehog.*Tests.dll"
     |> xUnit2 (fun p -> { p with Parallel = ParallelMode.All }))
 
+Target "NuGet" (fun _ ->
+    Paket.Pack (fun p -> { p with OutputPath = ".nuget" }))
+
 "Build"
 ==> "Test"
+==> "NuGet"
 
 RunTargetOrDefault "Test"


### PR DESCRIPTION
As described in #72.

---

Usage:

```
$ ./build.sh NuGet
```

Sample output:

![image](https://cloud.githubusercontent.com/assets/287532/24258984/123dc0fe-0ff8-11e7-8a5d-cd4c9078c22f.png)

---

**Note** that we still need another build target to *push* the created NuGet package on NuGet Gallery.