### PR TITLE
Update references in Script.fsx

### DIFF
--- a/src/Hedgehog/Script.fsx
+++ b/src/Hedgehog/Script.fsx
@@ -1,7 +1,7 @@
 ﻿#if INTERACTIVE
-#load "../paket-files/fsprojects/FSharpx.Collections/src/FSharpx.Collections/Collections.fs"
-      "../paket-files/fsprojects/FSharpx.Collections/src/FSharpx.Collections/LazyList.fsi"
-      "../paket-files/fsprojects/FSharpx.Collections/src/FSharpx.Collections/LazyList.fs"
+#load "../../paket-files/fsprojects/FSharpx.Collections/src/FSharpx.Collections/Collections.fs"
+      "../../paket-files/fsprojects/FSharpx.Collections/src/FSharpx.Collections/LazyList.fsi"
+      "../../paket-files/fsprojects/FSharpx.Collections/src/FSharpx.Collections/LazyList.fs"
       "Numeric.fs"
       "Seed.fs"
       "Tree.fs"


### PR DESCRIPTION
In c451bba0c0e8254cd52b69bfce01a61e8c75f2de, and #76, we changed the directory structure but I forgot to update the references in Script.fsx.
